### PR TITLE
rootfsimg: Auto populate /dev

### DIFF
--- a/rootfsimg/inittab
+++ b/rootfsimg/inittab
@@ -3,4 +3,7 @@
 ::sysinit:/bin/busybox mount -t tmpfs tmpfs /tmp
 ::sysinit:/bin/busybox mount -o remount,rw /dev/htifbd0 /
 ::sysinit:/bin/busybox --install -s
-/dev/console::sysinit:-/bin/ash 
+::sysinit:/bin/mkdir -p /dev/pts
+::sysinit:/bin/echo /bin/mdev > /proc/sys/kernel/hotplug
+::sysinit:/sbin/mdev -s
+/dev/console::sysinit:-/bin/ash


### PR DESCRIPTION
Use mdev (mini udev) to populate /dev.
Adds a couple of seconds to the boot time but I'll take it over
manually maintaining /dev.